### PR TITLE
fix file parsing in` _form_result_path` function

### DIFF
--- a/src/thug/cli.py
+++ b/src/thug/cli.py
@@ -58,7 +58,7 @@ def _load_configuration(override, show_and_exit):
 
 def _form_result_path(orig_path, result_dir, fname_extra=''):
     fname = osp.basename(orig_path)
-    base, extension = fname.split('.')
+    base, extension = osp.splitext(fname)
     fname = '{}{}.{}'.format(base, fname_extra, extension)
     return osp.join(result_dir, fname)
 


### PR DESCRIPTION
Default `split` function doesn't work correctly when file name consists dots. Changed it to `os.path.splitext`